### PR TITLE
The initial port is 6000, no need to mention it

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a protocol adaptor that allows you to remote debug Firefox instances via
 ## Getting started
 
 1. Run `npm install`
-2. Start Firefox with remote debugging enabled using `path/to/firefox --start-debugger-server 6000`
+2. Start Firefox with remote debugging enabled using `path/to/firefox --start-debugger-server`
 3. Run `npm start`
 4. Open `http://localhost:9222/json` in Chrome.
 5. Locate your tab in the json-output, and open the `devtoolsUrl` url in Chrome.


### PR DESCRIPTION
> https://developer.mozilla.org/en-US/docs/Tools/Remote_Debugging/Debugging_Firefox_Desktop
> Passed with no arguments, --start-debugger-server makes the debugger server listen on port 6000
